### PR TITLE
Fix for bug in seed-based mapping analyses

### DIFF
--- a/01_seed_subject_correlation_maps.sh
+++ b/01_seed_subject_correlation_maps.sh
@@ -22,10 +22,21 @@ path_seeds=$PWD/02_seeds/ # edit this, folder containing seeds
 
 numjobs=7
 
+
+function warnings_seed_names {
+  seed=$1
+  seed_name=$(basename $seed .nii.gz)
+  SUB='_' #offending character
+
+  if [[ "$seed_name" == *"$SUB"* ]]; then
+    echo -e "\e[43m {$seed_name}: Please use a seed name without underscores (_), as this might be problematic for group-level analyses\e[0m"
+  fi
+}
+
 function seed_subject_correlation_map {
     ts=$1
     seed=$2
-    brainmask=/home/imaging/config/scripts/restingstate_scripts/chd8_functional_template_mask_wo_cerebellum.nii.gz #edit this
+    brainmask=/home/imaging/Silvia_Gini/seed_based_bug/chd8_functional_template_mask.nii.gz #edit this
 
     subj_name=$(basename $ts .nii.gz)
     seed_name=$(basename $seed .nii.gz)
@@ -57,6 +68,12 @@ echo $path_ts/ag*.nii.gz | tr " " "\n" > tslist.txt
 echo $path_seeds/*.nii.gz | tr " " "\n" > seedlist.txt
 
 mkdir 03_subject_maps
+
+
+while read -r seed;
+	do
+	warnings_seed_names $seed
+	done < seedlist.txt
 
 while read -r seed;
 do

--- a/01_seed_subject_correlation_maps.sh
+++ b/01_seed_subject_correlation_maps.sh
@@ -6,12 +6,12 @@
 # seed inter-group differences measured with global connectivity
 # as in Pagani et al NatComm 2020 (Figure 1). The output is a
 # voxelwise pearson's correlation map for each ts and each seed,
-# that you will use for intergroup comparisons (e.g. wild-type 
+# that you will use for intergroup comparisons (e.g. wild-type
 # mice vs ko mice).
 #
 # -----------------------------------------------------------
 # Script written by Marco Pagani
-# Functional Neuroimaging Lab, 
+# Functional Neuroimaging Lab,
 # Istituto Italiano di Tecnologia, Rovereto
 # (2018)
 # -----------------------------------------------------------

--- a/01_seed_subject_correlation_maps.sh
+++ b/01_seed_subject_correlation_maps.sh
@@ -36,7 +36,7 @@ function warnings_seed_names {
 function seed_subject_correlation_map {
     ts=$1
     seed=$2
-    brainmask=/home/imaging/Silvia_Gini/seed_based_bug/chd8_functional_template_mask.nii.gz #edit this
+    brainmask=/home/seed_based_bug/chd8_functional_template_mask.nii.gz #edit this
 
     subj_name=$(basename $ts .nii.gz)
     seed_name=$(basename $seed .nii.gz)

--- a/02_seed_group_one_sample.sh
+++ b/02_seed_group_one_sample.sh
@@ -4,6 +4,11 @@
 # Use this code in case you have only one group in your study
 # Use this script after 01_seed_subjects_correlation_maps.sh as you need seedlist.txt
 #
+# NB: When running the script, make sure the seed names in the $path_seeds folder do not contain underscores.
+# We have added an extra check that prints an error and kills the script if an underscore in present.
+# To double check the script is appropriately grouping your subjects, the subjects in each group are listed
+# in ts_list_${seed}.txt files in the 04_groups_log folder.
+#
 # -----------------------------------------------------------
 # Script written by Marco Pagani
 # Functional Neuroimaging Lab,
@@ -49,9 +54,26 @@ rm 04_group_level/${seed_name}_results.nii.gz
 }
 export -f seed_group_level_map
 
+function check_groups {
+
+   seed=$1
+   seed_name=$(basename $seed .nii.gz)
+
+   path_ts=03_subject_maps
+
+   echo $path_ts/*_${seed_name}_z.nii.gz | tr " " "\n" > 04_groups_log/tslist_${seed_name}.txt
+
+
+}
+
 # Main starts here
 
-mkdir 04_group_level
+mkdir 04_group_level 04_groups_log
+
+while read -r seed;
+	do
+	check_groups $seed
+	done < $seedlist
 
 while read -r seed;
 	do

--- a/02_seed_group_one_sample.sh
+++ b/02_seed_group_one_sample.sh
@@ -18,6 +18,8 @@
 
 seedlist=seedlist.txt
 
+path_ts=03_subject_maps # edit here if necessary
+
 function check_seed_name {
   seed=$1
   seed_name=$(basename $seed .nii.gz)
@@ -59,16 +61,15 @@ function check_groups {
    seed=$1
    seed_name=$(basename $seed .nii.gz)
 
-   path_ts=03_subject_maps
 
-   echo $path_ts/*_${seed_name}_z.nii.gz | tr " " "\n" > 04_groups_log/tslist_${seed_name}.txt
+   echo $path_ts/*_${seed_name}_z.nii.gz | tr " " "\n" > 04_groups_level/logs/tslist_${seed_name}.txt
 
 
 }
 
 # Main starts here
 
-mkdir 04_group_level 04_groups_log
+mkdir 04_group_level 04_groups_level/logs
 
 while read -r seed;
 	do

--- a/02_seed_group_one_sample.sh
+++ b/02_seed_group_one_sample.sh
@@ -1,20 +1,32 @@
 #!/bin/bash
 
-# This script performs one-sample t-test of seed based connectivity mapping. 
+# This script performs one-sample t-test of seed based connectivity mapping.
 # Use this code in case you have only one group in your study
-# Use this script after 01_seed_subjects_correlation_maps.sh as you need seedlist.txt 
+# Use this script after 01_seed_subjects_correlation_maps.sh as you need seedlist.txt
 #
 # -----------------------------------------------------------
 # Script written by Marco Pagani
-# Functional Neuroimaging Lab, 
+# Functional Neuroimaging Lab,
 # Istituto Italiano di Tecnologia, Rovereto
 # (2018)
 # -----------------------------------------------------------
 
 seedlist=seedlist.txt
 
+function check_seed_name {
+  seed=$1
+  seed_name=$(basename $seed .nii.gz)
+  SUB='_' #offending character
+
+  if [[ "$seed_name" == *"$SUB"* ]]; then
+    echo "{$seed_name}: This naming convention is not permitted. Please use a seed name without underscores (_)"
+    echo "Error: Aborting script"
+    exit 1
+  fi
+}
+
 function seed_group_level_map {
- 
+
     seed=$1
     seed_name=$(basename $seed .nii.gz)
 
@@ -32,7 +44,7 @@ function seed_group_level_map {
         -expr "a" \
         -prefix 04_group_level/${seed_name}_onesample_Tstat.nii.gz
 
-rm 04_group_level/${seed_name}_results.nii.gz 
+rm 04_group_level/${seed_name}_results.nii.gz
 
 }
 export -f seed_group_level_map
@@ -43,9 +55,13 @@ mkdir 04_group_level
 
 while read -r seed;
 	do
+	check_seed_name $seed
+	done < $seedlist
+
+while read -r seed;
+	do
 	seed_group_level_map $seed
 	done < $seedlist
 
 
 exit
-

--- a/02_seed_group_two_sample.sh
+++ b/02_seed_group_two_sample.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script performs one-sample t-tests, unpaired t-test of 
+# This script performs one-sample t-tests, unpaired t-test of
 # seed based connectivity maps. this code also outputs mean connectivity
 # (pearson's correlation) maps for each group.
 # Use this script after 01_seed_subjects_correlation_maps.sh
@@ -9,21 +9,34 @@
 #
 # -----------------------------------------------------------
 # Script written by Marco Pagani
-# Functional Neuroimaging Lab, 
+# Functional Neuroimaging Lab,
 # Istituto Italiano di Tecnologia, Rovereto
 # (2018)
 # -----------------------------------------------------------
 
 seedlist=seedlist.txt
 
+function check_seed_name {
+  seed=$1
+  seed_name=$(basename $seed .nii.gz)
+  SUB='_' #offending character
+
+  if [[ "$seed_name" == *"$SUB"* ]]; then
+    echo "{$seed_name}: This naming convention is not permitted. Please use a seed name without underscores (_)"
+    echo "Error: Aborting script"
+    exit 1
+  fi
+}
+
+
 function seed_group_level_map {
- 
+
     seed=$1
     seed_name=$(basename $seed .nii.gz)
 
     groupA=KO #edit this
     groupB=WT #edit this
-    
+
     3dttest++ \
         -setA 03_subject_maps/*_${groupA}_*_${seed_name}_z.nii.gz \
         -setB 03_subject_maps/*_${groupB}_*_${seed_name}_z.nii.gz \
@@ -59,7 +72,7 @@ function seed_group_level_map {
         -expr "a" \
         -prefix 04_group_level/${seed_name}_${groupB}_Tstat.nii.gz
 
-    rm 04_group_level/${seed_name}_results.nii.gz 
+    rm 04_group_level/${seed_name}_results.nii.gz
 
 }
 export -f seed_group_level_map
@@ -70,8 +83,10 @@ mkdir 04_group_level
 
 while read -r seed;
 	do
-	seed_group_level_map $seed
+	check_seed_name $seed
 	done < $seedlist
 
-
-
+while read -r seed;
+	do
+	seed_group_level_map $seed
+	done < $seedlist

--- a/02_seed_group_two_sample.sh
+++ b/02_seed_group_two_sample.sh
@@ -8,7 +8,7 @@
 # seedlist.txt has been already produced with 01_seed_subjects_correlation_maps.sh
 #
 # NB: When running the script, make sure the seed names in the $path_seeds folder do not contain underscores.
-# We have added an extra check that prints an error if an underscore in present.
+# We have added an extra check that prints an error and kills the script if an underscore in present.
 # To double check the script is appropriately grouping your subjects, the subjects in each group are listed
 # in ts_list_${group}_${seed}.txt files in the 04_groups_log folder.
 #
@@ -105,6 +105,7 @@ while read -r seed;
 	do
 	check_groups $seed
 	done < $seedlist
+
 while read -r seed;
 	do
 	check_seed_name $seed

--- a/02_seed_group_two_sample.sh
+++ b/02_seed_group_two_sample.sh
@@ -7,6 +7,11 @@
 # groupA and groupB are the group names contained in the filenames.
 # seedlist.txt has been already produced with 01_seed_subjects_correlation_maps.sh
 #
+# NB: When running the script, make sure the seed names in the $path_seeds folder do not contain underscores.
+# We have added an extra check that prints an error if an underscore in present.
+# To double check the script is appropriately grouping your subjects, the subjects in each group are listed
+# in ts_list_${group}_${seed}.txt files in the 04_groups_log folder.
+#
 # -----------------------------------------------------------
 # Script written by Marco Pagani
 # Functional Neuroimaging Lab,
@@ -77,10 +82,29 @@ function seed_group_level_map {
 }
 export -f seed_group_level_map
 
+
+
+function check_groups {
+
+   seed=$1
+   seed_name=$(basename $seed .nii.gz)
+   groupA=HT #edit here as above
+   groupB=WT #edit here as above
+   path_ts=03_subject_maps
+
+   echo $path_ts/*_${groupA}_*_${seed_name}_z.nii.gz | tr " " "\n" > 04_groups_log/tslist_${groupA}_${seed_name}.txt
+   echo $path_ts/*_${groupB}_*_${seed_name}_z.nii.gz | tr " " "\n" > 04_groups_log/tslist_${groupB}_${seed_name}.txt
+
+}
+
 # Main starts here
 
-mkdir 04_group_level
+mkdir 04_group_level 04_groups_log
 
+while read -r seed;
+	do
+	check_groups $seed
+	done < $seedlist
 while read -r seed;
 	do
 	check_seed_name $seed

--- a/02_seed_group_two_sample.sh
+++ b/02_seed_group_two_sample.sh
@@ -7,7 +7,7 @@
 # groupA and groupB are the group names contained in the filenames.
 # seedlist.txt has been already produced with 01_seed_subjects_correlation_maps.sh
 #
-# NB: When running the script, make sure the seed names in the $path_seeds folder do not contain underscores.
+# # NB: When running the script, make sure the seed names in the $path_seeds folder do not contain underscores.
 # We have added an extra check that prints an error and kills the script if an underscore in present.
 # To double check the script is appropriately grouping your subjects, the subjects in each group are listed
 # in ts_list_${group}_${seed}.txt files in the 04_groups_log folder.
@@ -20,6 +20,12 @@
 # -----------------------------------------------------------
 
 seedlist=seedlist.txt
+
+groupA=KO #edit this
+groupB=WT #edit this
+
+path_ts=03_subject_maps #edit this, where your seed based connectivity maps are stored
+
 
 function check_seed_name {
   seed=$1
@@ -39,8 +45,6 @@ function seed_group_level_map {
     seed=$1
     seed_name=$(basename $seed .nii.gz)
 
-    groupA=KO #edit this
-    groupB=WT #edit this
 
     3dttest++ \
         -setA 03_subject_maps/*_${groupA}_*_${seed_name}_z.nii.gz \
@@ -88,18 +92,15 @@ function check_groups {
 
    seed=$1
    seed_name=$(basename $seed .nii.gz)
-   groupA=HT #edit here as above
-   groupB=WT #edit here as above
-   path_ts=03_subject_maps
 
-   echo $path_ts/*_${groupA}_*_${seed_name}_z.nii.gz | tr " " "\n" > 04_groups_log/tslist_${groupA}_${seed_name}.txt
-   echo $path_ts/*_${groupB}_*_${seed_name}_z.nii.gz | tr " " "\n" > 04_groups_log/tslist_${groupB}_${seed_name}.txt
+   echo $path_ts/*_${groupA}_*_${seed_name}_z.nii.gz | tr " " "\n" > 04_group_level/logs/tslist_${groupA}_${seed_name}.txt
+   echo $path_ts/*_${groupB}_*_${seed_name}_z.nii.gz | tr " " "\n" > 04_group_level/logs/tslist_${groupB}_${seed_name}.txt
 
 }
 
 # Main starts here
 
-mkdir 04_group_level 04_groups_log
+mkdir 04_group_level 04_group_level/logs
 
 while read -r seed;
 	do


### PR DESCRIPTION
The presence of the asterisk in the file identification step of the 02_seed_group_one_sample.sh/02_seed_group_two_sample.sh was problematic as it lead to unpredicted behavior in the grouping of individual scans for group level statistics. 

To counter this, with the help of @edeguzman, we implemented the following: 

1. A warning at the beginning of 01_seed_subject_correlation_maps.sh that appears in case of seeds containing underscores to warn the user of possible unexpected behaviors at the group level. This warning does not stop the maps from being computed;
2. A check at the beginning of 02_seed_group_one_sample.sh/02_seed_group_two_sample.sh, which reads in the seed names and throws an error if any of the seed names contain an underscore;
3. The output of a text file from 02_seed_group_one_sample.sh/02_seed_group_two_sample.sh, which lists the names of all the “subjects” included in each statistic, allowing the user to verify that the subjects are being appropriately identified and grouped.
4. I also moved the group variables out of the functions and at the top of the scripts so that the user has to edit them only once


Happy to hear your thoughts on this and discuss possible further improvements :) 
 